### PR TITLE
feat: add MimeType detection to StatFile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.32.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.43
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.3
+	github.com/gabriel-vasile/mimetype v1.4.7
 	github.com/google/safeopen v0.0.0-20240125081138-66b54d5181c6
 	github.com/google/uuid v1.6.0
 	github.com/gptscript-ai/cmd v0.0.0-20240907001148-ffd49061124a
@@ -40,6 +41,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/net v0.31.0 // indirect
+	golang.org/x/sys v0.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/aws/smithy-go v1.22.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxY
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gabriel-vasile/mimetype v1.4.7 h1:SKFKl7kD0RiPdbht0s7hFtjl489WcQ1VyPW8ZzUMYCA=
+github.com/gabriel-vasile/mimetype v1.4.7/go.mod h1:GDlAgAyIRT27BhFl53XNAFtfjzOkLaF35JdEG0P7LtU=
 github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=
 github.com/getkin/kin-openapi v0.124.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
 github.com/go-openapi/jsonpointer v0.20.2 h1:mQc3nmndL8ZBzStEo3JYF8wzmeWffDH4VbXz58sAx6Q=
@@ -84,8 +86,10 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
-golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
-golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
+golang.org/x/net v0.31.0/go.mod h1:P4fl1q7dY2hnZFxEk4pPSkDHF+QqjitcnDjUQyMM+pM=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pkg/client/directory.go
+++ b/pkg/client/directory.go
@@ -144,12 +144,11 @@ func (d *directoryProvider) StatFile(_ context.Context, s string) (FileInfo, err
 	}
 
 	// Get Mimetype
-	var mime string
 	mt, err := mimetype.DetectReader(f)
 	if err != nil {
 		return FileInfo{}, err
 	}
-	mime = strings.Split(mt.String(), ";")[0]
+	mime := strings.Split(mt.String(), ";")[0]
 
 	return FileInfo{
 		WorkspaceID: DirectoryProvider + "://" + d.dataHome,

--- a/pkg/client/directory.go
+++ b/pkg/client/directory.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/adrg/xdg"
+	"github.com/gabriel-vasile/mimetype"
 	"github.com/google/safeopen"
 	"github.com/google/uuid"
 )
@@ -142,11 +143,20 @@ func (d *directoryProvider) StatFile(_ context.Context, s string) (FileInfo, err
 		return FileInfo{}, err
 	}
 
+	// Get Mimetype
+	var mime string
+	mt, err := mimetype.DetectReader(f)
+	if err != nil {
+		return FileInfo{}, err
+	}
+	mime = strings.Split(mt.String(), ";")[0]
+
 	return FileInfo{
 		WorkspaceID: DirectoryProvider + "://" + d.dataHome,
 		Name:        stat.Name(),
 		Size:        stat.Size(),
 		ModTime:     stat.ModTime(),
+		MimeType:    mime,
 	}, nil
 }
 

--- a/pkg/client/fileinfo.go
+++ b/pkg/client/fileinfo.go
@@ -7,4 +7,5 @@ type FileInfo struct {
 	Name        string    `json:"name"`
 	Size        int64     `json:"size"`
 	ModTime     time.Time `json:"modTime"`
+	MimeType    string    `json:"mimeType"`
 }


### PR DESCRIPTION
This improves experience with knowledge, as we don't have to pull a whole file from S3 just to detect the mimetype from the first few bytes.
Other options would require us to add extra subtools and touch too many other pieces of code, so this is the easiest to implement and clean solution.