### PR TITLE
Fix: fix the prefix to not have slash in the end

### DIFF
--- a/pkg/client/directory.go
+++ b/pkg/client/directory.go
@@ -162,7 +162,7 @@ func (d *directoryProvider) StatFile(_ context.Context, s string) (FileInfo, err
 func (d *directoryProvider) Ls(ctx context.Context, prefix string) ([]string, error) {
 	if prefix != "" {
 		// Ensure that the provided prefix is safe to open.
-		file, err := safeopen.OpenBeneath(d.dataHome, prefix)
+		file, err := safeopen.OpenBeneath(d.dataHome, strings.TrimSuffix(prefix, "/"))
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, nil

--- a/pkg/client/directory_test.go
+++ b/pkg/client/directory_test.go
@@ -367,26 +367,31 @@ func TestLsWithPrefix(t *testing.T) {
 		}()
 	}
 
-	contents, err := dirPrv.Ls(context.Background(), "testDir")
-	if err != nil {
-		t.Fatalf("unexpected error when listing files: %v", err)
-	}
+	for _, input := range []string{
+		"testDir",
+		"testDir/",
+	} {
+		contents, err := dirPrv.Ls(context.Background(), input)
+		if err != nil {
+			t.Fatalf("unexpected error when listing files: %v", err)
+		}
 
-	if len(contents) != 4 {
-		t.Errorf("unexpected number of contents: %d", len(contents))
-	}
+		if len(contents) != 4 {
+			t.Errorf("unexpected number of contents: %d", len(contents))
+		}
 
-	sort.Strings(contents)
-	if !reflect.DeepEqual(
-		contents,
-		[]string{
-			filepath.Join("testDir", "test3.txt"),
-			filepath.Join("testDir", "test4.txt"),
-			filepath.Join("testDir", "test5.txt"),
-			filepath.Join("testDir", "test6.txt"),
-		},
-	) {
-		t.Errorf("unexpected contents: %v", contents)
+		sort.Strings(contents)
+		if !reflect.DeepEqual(
+			contents,
+			[]string{
+				filepath.Join("testDir", "test3.txt"),
+				filepath.Join("testDir", "test4.txt"),
+				filepath.Join("testDir", "test5.txt"),
+				filepath.Join("testDir", "test6.txt"),
+			},
+		) {
+			t.Errorf("unexpected contents: %v", contents)
+		}
 	}
 }
 


### PR DESCRIPTION
Adding the slash in prefix seems to be break. safeopen.OpenBeneath will return non-existing error. 

This cause the local workspace provider to be broken when using prefix 