### PR TITLE
enhance: add latest revision to write options

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -170,6 +170,8 @@ func (c *Client) OpenFile(ctx context.Context, id, fileName string) (io.ReadClos
 
 type WriteOptions struct {
 	CreateRevision *bool
+	// If LatestRevision is set, then a conflict error will be returned if that revision is not the latest.
+	LatestRevision string
 }
 
 func (c *Client) WriteFile(ctx context.Context, id, fileName string, reader io.Reader, opts ...WriteOptions) error {
@@ -177,6 +179,9 @@ func (c *Client) WriteFile(ctx context.Context, id, fileName string, reader io.R
 	for _, o := range opts {
 		if o.CreateRevision != nil {
 			opt.CreateRevision = o.CreateRevision
+		}
+		if o.LatestRevision != "" {
+			opt.LatestRevision = o.LatestRevision
 		}
 	}
 	wc, err := c.getClient(id)

--- a/pkg/client/directory.go
+++ b/pkg/client/directory.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/adrg/xdg"
@@ -143,6 +144,17 @@ func (d *directoryProvider) WriteFile(ctx context.Context, fileName string, read
 		if err != nil {
 			if nfe := (*NotFoundError)(nil); !errors.As(err, &nfe) {
 				return err
+			}
+		}
+
+		if opt.LatestRevision != "" {
+			requiredLatestRevision, err := strconv.ParseInt(opt.LatestRevision, 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse latest revision for write: %w", err)
+			}
+
+			if requiredLatestRevision != info.CurrentID {
+				return newConflictError(DirectoryProvider+"://"+d.dataHome, fileName, opt.LatestRevision, fmt.Sprintf("%d", info.CurrentID))
 			}
 		}
 

--- a/pkg/client/directory_test.go
+++ b/pkg/client/directory_test.go
@@ -582,6 +582,86 @@ func TestWriteEnsureNoRevision(t *testing.T) {
 	}
 }
 
+func TestWriteEnsureConflict(t *testing.T) {
+	// Copy a file into the workspace
+	if err := dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test"), WriteOptions{}); err != nil {
+		t.Fatalf("error getting file to write: %v", err)
+	}
+
+	// List revisions, there should be none
+	revisions, err := dirPrv.ListRevisions(context.Background(), "test.txt")
+	if err != nil {
+		t.Errorf("unexpected error when listing revisions: %v", err)
+	}
+	if len(revisions) != 0 {
+		t.Errorf("unexpected number of revisions: %d", len(revisions))
+	}
+
+	ce := (*ConflictError)(nil)
+	// Trying to update the file with a non-zero revision ID should fail with a conflict error.
+	if err = dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{LatestRevision: "1"}); err == nil || !errors.As(err, &ce) {
+		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
+	}
+
+	// Update the file
+	if err = dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{}); err != nil {
+		t.Errorf("error getting file to write: %v", err)
+	}
+
+	// Now there should be one revision
+	revisions, err = dirPrv.ListRevisions(context.Background(), "test.txt")
+	if err != nil {
+		t.Errorf("unexpected error when listing revisions: %v", err)
+	}
+	if len(revisions) != 1 {
+		t.Errorf("unexpected number of revisions: %d", len(revisions))
+	}
+
+	// Update the file again
+	if err = dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test3"), WriteOptions{LatestRevision: revisions[0].RevisionID}); err != nil {
+		t.Errorf("error getting file to write: %v", err)
+	}
+
+	// Now there should be two revisions
+	revisions, err = dirPrv.ListRevisions(context.Background(), "test.txt")
+	if err != nil {
+		t.Errorf("unexpected error when listing revisions: %v", err)
+	}
+	if len(revisions) != 2 {
+		t.Errorf("unexpected number of revisions: %d", len(revisions))
+	}
+
+	ce = (*ConflictError)(nil)
+	// Trying to update the file again with the same revision ID should fail with a conflict error.
+	if err = dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test4"), WriteOptions{LatestRevision: revisions[0].RevisionID}); err == nil || !errors.As(err, &ce) {
+		t.Errorf("expected error when updating file with same revision ID: %v", err)
+	}
+
+	// Delete the most recent revision
+	if err = dirPrv.DeleteRevision(context.Background(), "test.txt", revisions[1].RevisionID); err != nil {
+		t.Errorf("error deleting revision: %v", err)
+	}
+
+	// Now there should be one revision
+	revisions, err = dirPrv.ListRevisions(context.Background(), "test.txt")
+	if err != nil {
+		t.Errorf("unexpected error when listing revisions: %v", err)
+	}
+	if len(revisions) != 1 {
+		t.Errorf("unexpected number of revisions: %d", len(revisions))
+	}
+
+	// Ensure that we can still create a new revision
+	if err = dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test5"), WriteOptions{LatestRevision: revisions[0].RevisionID}); err != nil {
+		t.Errorf("error getting file to write: %v", err)
+	}
+
+	// Delete the file
+	if err = dirPrv.DeleteFile(context.Background(), "test.txt"); err != nil {
+		t.Errorf("error removing file: %v", err)
+	}
+}
+
 func TestDeleteRevision(t *testing.T) {
 	// Copy a file into the workspace
 	if err := dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test"), WriteOptions{}); err != nil {

--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -16,3 +16,18 @@ func (e *NotFoundError) Error() string {
 func newNotFoundError(id, name string) *NotFoundError {
 	return &NotFoundError{id: id, name: name}
 }
+
+type ConflictError struct {
+	id              string
+	name            string
+	latestRevision  string
+	currentRevision string
+}
+
+func newConflictError(id, name, latestRevision, currentRevision string) *ConflictError {
+	return &ConflictError{id: id, name: name, latestRevision: latestRevision, currentRevision: currentRevision}
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("conflict: %s/%s (latest revision: %s, current revision: %s)", e.id, e.name, e.latestRevision, e.currentRevision)
+}

--- a/pkg/client/fileinfo.go
+++ b/pkg/client/fileinfo.go
@@ -16,5 +16,5 @@ type RevisionInfo struct {
 }
 
 type revisionInfo struct {
-	CurrentID int `json:"currentID"`
+	CurrentID int64 `json:"currentID"`
 }

--- a/pkg/server/writefile.go
+++ b/pkg/server/writefile.go
@@ -13,9 +13,9 @@ func (s *server) writeFile(w http.ResponseWriter, r *http.Request) {
 	fileName := r.PathValue("fileName")
 	query := r.URL.Query()
 
-	opts := client.WriteOptions{}
-	if query.Get("createRevision") == "false" {
-		opts.CreateRevision = new(bool)
+	opts := client.WriteOptions{
+		LatestRevision: query.Get("latestRevision"),
+		CreateRevision: toPtr(query.Get("createRevision") != "false"),
 	}
 
 	if err := s.client.WriteFile(r.Context(), id, fileName, base64.NewDecoder(base64.StdEncoding, r.Body), opts); err != nil {
@@ -25,4 +25,8 @@ func (s *server) writeFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, _ = w.Write([]byte(fmt.Sprintf("file %s has been written to workspace %s", fileName, id)))
+}
+
+func toPtr[T any](t T) *T {
+	return &t
 }

--- a/tool.gpt
+++ b/tool.gpt
@@ -40,8 +40,9 @@ Parameter: workspace_id: The ID of the workspaces to write the file in
 Parameter: file_path: The name of the file to write
 Parameter: body: The base64 encoded contents of the file to write
 Parameter: create_revision: Whether to create a revision of the change to the file
+Parameter: latest_revision: Only write the file if the given revision is the latest (optional)
 
-#!http://Server.daemon.gptscript.local/write-file/${WORKSPACE_ID}/${FILE_PATH}?createRevision=${CREATE_REVISION}
+#!http://Server.daemon.gptscript.local/write-file/${WORKSPACE_ID}/${FILE_PATH}?createRevision=${CREATE_REVISION}&latestRevision=${LATEST_REVISION}
 
 ---
 Name: Read File in Workspace


### PR DESCRIPTION
If the latest revision write option is passed and this is not the latest revision, then writing the file will fail with a conflict error. If the latest revision write option is not passed, then no check is done and writing will not fail with a conflict.