### PR TITLE
enhance: add ability to request current revision ID when opening a file

### DIFF
--- a/pkg/cli/readfile.go
+++ b/pkg/cli/readfile.go
@@ -4,13 +4,15 @@ import (
 	"encoding/base64"
 	"io"
 
+	"github.com/gptscript-ai/workspace-provider/pkg/client"
 	"github.com/spf13/cobra"
 )
 
 type readFile struct {
 	root *workspaceProvider
 
-	Base64EncodeOutput bool `usage:"Encode output as base64" env:"READ_FILE_BASE64_ENCODE_OUTPUT"`
+	Base64EncodeOutput   bool `usage:"Encode output as base64" env:"READ_FILE_BASE64_ENCODE_OUTPUT"`
+	WithLatestRevisionID bool `usage:"Include the latest revision" env:"READ_FILE_WITH_LATEST_REVISION_ID"`
 }
 
 func (r *readFile) Customize(c *cobra.Command) {
@@ -20,7 +22,9 @@ func (r *readFile) Customize(c *cobra.Command) {
 }
 
 func (r *readFile) Run(cmd *cobra.Command, args []string) error {
-	file, err := r.root.client.OpenFile(cmd.Context(), args[0], args[1])
+	file, err := r.root.client.OpenFile(cmd.Context(), args[0], args[1], client.OpenOptions{
+		WithLatestRevisionID: r.WithLatestRevisionID,
+	})
 	if err != nil {
 		return err
 	}
@@ -31,6 +35,15 @@ func (r *readFile) Run(cmd *cobra.Command, args []string) error {
 		enc := base64.NewEncoder(base64.StdEncoding, cmd.OutOrStdout())
 		defer enc.Close()
 		writer = enc
+	}
+
+	if r.WithLatestRevisionID {
+		rev, err := file.GetRevisionID()
+		if err != nil {
+			_, _ = writer.Write([]byte("revision ID: <not available>\n"))
+		} else {
+			_, _ = writer.Write([]byte("revision ID: " + rev + "\n"))
+		}
 	}
 
 	_, err = io.Copy(writer, file)

--- a/pkg/cli/statfile.go
+++ b/pkg/cli/statfile.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/gptscript-ai/workspace-provider/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+type statFile struct {
+	root *workspaceProvider
+
+	WithLatestRevisionID bool `usage:"Include latest revision" env:"STAT_FILE_WITH_LATEST_REVISION_ID"`
+}
+
+func (r *statFile) Customize(c *cobra.Command) {
+	c.Args = cobra.ExactArgs(2)
+	c.Use = "stat-file [OPTIONS] ID FILE"
+	c.Short = "Get file stats from a workspace"
+}
+
+func (r *statFile) Run(cmd *cobra.Command, args []string) error {
+	info, err := r.root.client.StatFile(cmd.Context(), args[0], args[1], client.StatOptions{
+		WithLatestRevisionID: r.WithLatestRevisionID,
+	})
+	if err != nil {
+		return err
+	}
+
+	writer := cmd.OutOrStdout()
+
+	_, _ = writer.Write([]byte("workspace id: " + info.WorkspaceID + "\n"))
+	_, _ = writer.Write([]byte("name: " + info.Name + "\n"))
+	_, _ = writer.Write([]byte("size: " + strconv.FormatInt(info.Size, 10) + "\n"))
+	_, _ = writer.Write([]byte("mod time: " + info.ModTime.String() + "\n"))
+	_, _ = writer.Write([]byte("mime type: " + info.MimeType + "\n"))
+	if r.WithLatestRevisionID {
+		rev, err := info.GetRevisionID()
+		if err != nil {
+			_, _ = writer.Write([]byte("revision ID: <not available>\n"))
+		} else {
+			_, _ = writer.Write([]byte("revision ID: " + rev + "\n"))
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/workspace.go
+++ b/pkg/cli/workspace.go
@@ -31,6 +31,7 @@ func New() *cobra.Command {
 		&readFile{root: w},
 		&server{root: w},
 		&validateEnv{root: w},
+		&statFile{root: w},
 	)
 
 	c.CompletionOptions.HiddenDefaultCmd = true

--- a/pkg/cli/writefile.go
+++ b/pkg/cli/writefile.go
@@ -7,13 +7,16 @@ import (
 	"strings"
 
 	"github.com/gptscript-ai/go-gptscript"
+	"github.com/gptscript-ai/workspace-provider/pkg/client"
 	"github.com/spf13/cobra"
 )
 
 type writeFile struct {
 	root *workspaceProvider
 
-	Base64EncodedInput bool `usage:"Encode input as base64" env:"WRITE_FILE_BASE64_ENCODED_INPUT"`
+	Base64EncodedInput    bool   `usage:"Encode input as base64" env:"WRITE_FILE_BASE64_ENCODED_INPUT"`
+	WithoutCreateRevision bool   `usage:"Do not create a new revision" env:"WRITE_FILE_WITHOUT_CREATE_REVISION"`
+	LatestRevisionID      string `usage:"Only write if this is the latest revision" env:"WRITE_FILE_LATEST_REVISION_ID"`
 }
 
 func (c *writeFile) Customize(cmd *cobra.Command) {
@@ -34,5 +37,8 @@ func (c *writeFile) Run(cmd *cobra.Command, args []string) error {
 		source = base64.NewDecoder(base64.StdEncoding, source)
 	}
 
-	return c.root.client.WriteFile(cmd.Context(), args[0], args[1], source)
+	return c.root.client.WriteFile(cmd.Context(), args[0], args[1], source, client.WriteOptions{
+		LatestRevisionID: c.LatestRevisionID,
+		CreateRevision:   &[]bool{!c.WithoutCreateRevision}[0],
+	})
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -896,6 +896,12 @@ func TestConflictErrorDirectoryProvider(t *testing.T) {
 		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
 	}
 
+	fe := (*FileExistsError)(nil)
+	// Also, using IfNotExists: true should fail with a file exists error
+	if err = c.WriteFile(context.Background(), id, "test.txt", strings.NewReader("test2"), WriteOptions{IfNotExists: true}); err == nil || !errors.As(err, &fe) {
+		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
+	}
+
 	// Update the file
 	if err = c.WriteFile(context.Background(), id, "test.txt", strings.NewReader("test2")); err != nil {
 		t.Errorf("error getting file to write: %v", err)
@@ -981,6 +987,12 @@ func TestConflictErrorS3Provider(t *testing.T) {
 	ce := (*ConflictError)(nil)
 	// Trying to update the file with a non-zero revision ID should fail with a conflict error.
 	if err = c.WriteFile(context.Background(), id, "test.txt", strings.NewReader("test2"), WriteOptions{LatestRevisionID: "1"}); err == nil || !errors.As(err, &ce) {
+		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
+	}
+
+	fe := (*FileExistsError)(nil)
+	// Also, using IfNotExists: true should fail with a file exists error
+	if err = c.WriteFile(context.Background(), id, "test.txt", strings.NewReader("test2"), WriteOptions{IfNotExists: true}); err == nil || !errors.As(err, &fe) {
 		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
 	}
 
@@ -1085,7 +1097,7 @@ func TestOpenFileWithRevisionDirectoryProvider(t *testing.T) {
 	}
 
 	_, err = f.GetRevisionID()
-	if !errors.Is(err, ErrRevisionNotRequested) {
+	if !errors.Is(err, RevisionNotRequestedError) {
 		t.Errorf("unexpected error when getting revision: %v", err)
 	}
 
@@ -1168,7 +1180,7 @@ func TestOpenFileWithRevisionS3Provider(t *testing.T) {
 	}
 
 	_, err = f.GetRevisionID()
-	if !errors.Is(err, ErrRevisionNotRequested) {
+	if !errors.Is(err, RevisionNotRequestedError) {
 		t.Errorf("unexpected error when getting revision: %v", err)
 	}
 
@@ -1252,7 +1264,7 @@ func TestStatFileDirectoryProvider(t *testing.T) {
 	}
 
 	_, err = info.GetRevisionID()
-	if !errors.Is(err, ErrRevisionNotRequested) {
+	if !errors.Is(err, RevisionNotRequestedError) {
 		t.Errorf("unexpected error when getting revision: %v", err)
 	}
 
@@ -1317,7 +1329,7 @@ func TestStatFileS3Provider(t *testing.T) {
 	}
 
 	_, err = info.GetRevisionID()
-	if !errors.Is(err, ErrRevisionNotRequested) {
+	if !errors.Is(err, RevisionNotRequestedError) {
 		t.Errorf("unexpected error when getting revision: %v", err)
 	}
 

--- a/pkg/client/directory_test.go
+++ b/pkg/client/directory_test.go
@@ -611,6 +611,11 @@ func TestWriteEnsureConflict(t *testing.T) {
 		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
 	}
 
+	// Also, using -1 for the revision ID should also fail because that is the same as "only write if the file doesn't exist"
+	if err = dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{LatestRevisionID: "-1"}); err == nil || !errors.As(err, &ce) {
+		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
+	}
+
 	// Update the file
 	if err = dirPrv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{}); err != nil {
 		t.Errorf("error getting file to write: %v", err)
@@ -865,7 +870,7 @@ func TestStatFile(t *testing.T) {
 	if providerStat.ModTime.IsZero() {
 		t.Errorf("unexpected file mod time: %s", providerStat.ModTime)
 	}
-	if _, err := providerStat.GetRevisionID(); !errors.Is(err, ErrRevisionNotRequested) {
+	if _, err := providerStat.GetRevisionID(); !errors.Is(err, RevisionNotRequestedError) {
 		t.Errorf("unexpected error when revision not requested: %v", err)
 	}
 

--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 )
+
+var ErrRevisionNotRequested = errors.New("revision not requested")
 
 type NotFoundError struct {
 	id   string

--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-var ErrRevisionNotRequested = errors.New("revision not requested")
+var RevisionNotRequestedError = errors.New("revision not requested")
 
 type NotFoundError struct {
 	id   string
@@ -33,4 +33,10 @@ func newConflictError(id, name, latestRevision, currentRevision string) *Conflic
 
 func (e *ConflictError) Error() string {
 	return fmt.Sprintf("conflict: %s/%s (latest revision: %s, current revision: %s)", e.id, e.name, e.latestRevision, e.currentRevision)
+}
+
+type FileExistsError ConflictError
+
+func (e *FileExistsError) Error() string {
+	return fmt.Sprintf("file already exists: %s/%s", e.id, e.name)
 }

--- a/pkg/client/fileinfo.go
+++ b/pkg/client/fileinfo.go
@@ -8,11 +8,23 @@ type FileInfo struct {
 	Size        int64     `json:"size"`
 	ModTime     time.Time `json:"modTime"`
 	MimeType    string    `json:"mimeType"`
+	RevisionID  string    `json:"revisionID"`
+}
+
+func (f *FileInfo) GetRevisionID() (string, error) {
+	if f.RevisionID == "" {
+		return "", ErrRevisionNotRequested
+	}
+	return f.RevisionID, nil
 }
 
 type RevisionInfo struct {
 	FileInfo
 	RevisionID string `json:"revisionID"`
+}
+
+func (r *RevisionInfo) GetRevisionID() (string, error) {
+	return r.RevisionID, nil
 }
 
 type revisionInfo struct {

--- a/pkg/client/fileinfo.go
+++ b/pkg/client/fileinfo.go
@@ -13,7 +13,7 @@ type FileInfo struct {
 
 func (f *FileInfo) GetRevisionID() (string, error) {
 	if f.RevisionID == "" {
-		return "", ErrRevisionNotRequested
+		return "", RevisionNotRequestedError
 	}
 	return f.RevisionID, nil
 }

--- a/pkg/client/s3_test.go
+++ b/pkg/client/s3_test.go
@@ -556,6 +556,11 @@ func TestWriteEnsureConflictS3(t *testing.T) {
 		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
 	}
 
+	// Also, using -1 for the revision ID should also fail because that is the same as "only write if the file doesn't exist"
+	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{LatestRevisionID: "-1"}); err == nil || !errors.As(err, &ce) {
+		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
+	}
+
 	// Update the file
 	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{}); err != nil {
 		t.Errorf("error getting file to write: %v", err)
@@ -823,7 +828,7 @@ func TestStatFileS3(t *testing.T) {
 	if providerStat.ModTime.IsZero() {
 		t.Errorf("unexpected file mod time: %s", providerStat.ModTime)
 	}
-	if _, err := providerStat.GetRevisionID(); !errors.Is(err, ErrRevisionNotRequested) {
+	if _, err := providerStat.GetRevisionID(); !errors.Is(err, RevisionNotRequestedError) {
 		t.Errorf("unexpected error when revision not requested: %v", err)
 	}
 

--- a/pkg/client/s3_test.go
+++ b/pkg/client/s3_test.go
@@ -68,7 +68,7 @@ func TestWriteAndDeleteFileInS3(t *testing.T) {
 	defer obj.Body.Close()
 
 	// Stat the file and compare with the original
-	providerStat, err := s3Prv.StatFile(context.Background(), "test.txt")
+	providerStat, err := s3Prv.StatFile(context.Background(), "test.txt", StatOptions{})
 	if err != nil {
 		t.Errorf("unexpected error when statting file: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestFileReadFromS3(t *testing.T) {
 		t.Fatalf("error getting file to write: %v", err)
 	}
 
-	readFile, err := s3Prv.OpenFile(context.Background(), "test.txt")
+	readFile, err := s3Prv.OpenFile(context.Background(), "test.txt", OpenOptions{})
 	if err != nil {
 		t.Errorf("unexpected error when reading file: %v", err)
 	}
@@ -377,7 +377,7 @@ func TestOpeningFileDNENoErrorS3(t *testing.T) {
 	}
 
 	var notFoundError *NotFoundError
-	if file, err := s3Prv.OpenFile(context.Background(), "test.txt"); err == nil {
+	if file, err := s3Prv.OpenFile(context.Background(), "test.txt", OpenOptions{}); err == nil {
 		_ = file.Close()
 		t.Errorf("expected error when deleting file that doesn't exist")
 	} else if !errors.As(err, &notFoundError) {
@@ -456,6 +456,14 @@ func TestWriteEnsureRevisionS3(t *testing.T) {
 
 		if string(content) != "test" {
 			t.Errorf("unexpected content: %s", string(content))
+		}
+
+		revisionID, err := rev.GetRevisionID()
+		if err != nil {
+			t.Errorf("error getting revision: %v", err)
+		}
+		if revisionID != "1" {
+			t.Errorf("unexpected revision ID: %s", revisionID)
 		}
 	}
 
@@ -544,7 +552,7 @@ func TestWriteEnsureConflictS3(t *testing.T) {
 
 	ce := (*ConflictError)(nil)
 	// Trying to update the file with a non-zero revision ID should fail with a conflict error.
-	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{LatestRevision: "1"}); err == nil || !errors.As(err, &ce) {
+	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{LatestRevisionID: "1"}); err == nil || !errors.As(err, &ce) {
 		t.Errorf("expected error when first updating file non-zero revision ID: %v", err)
 	}
 
@@ -563,7 +571,7 @@ func TestWriteEnsureConflictS3(t *testing.T) {
 	}
 
 	// Update the file again
-	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test3"), WriteOptions{LatestRevision: revisions[0].RevisionID}); err != nil {
+	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test3"), WriteOptions{LatestRevisionID: revisions[0].RevisionID}); err != nil {
 		t.Errorf("error getting file to write: %v", err)
 	}
 
@@ -577,12 +585,13 @@ func TestWriteEnsureConflictS3(t *testing.T) {
 	}
 
 	// Trying to update the file again with the same revision ID should fail with a conflict error.
-	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test4"), WriteOptions{LatestRevision: revisions[0].RevisionID}); err == nil || !errors.As(err, &ce) {
+	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test4"), WriteOptions{LatestRevisionID: revisions[0].RevisionID}); err == nil || !errors.As(err, &ce) {
 		t.Errorf("expected error when updating file with same revision ID: %v", err)
 	}
 
+	latestRevisionID := revisions[1].RevisionID
 	// Delete the most recent revision
-	if err = s3Prv.DeleteRevision(context.Background(), "test.txt", revisions[1].RevisionID); err != nil {
+	if err = s3Prv.DeleteRevision(context.Background(), "test.txt", latestRevisionID); err != nil {
 		t.Errorf("error deleting revision: %v", err)
 	}
 
@@ -595,9 +604,96 @@ func TestWriteEnsureConflictS3(t *testing.T) {
 		t.Errorf("unexpected number of revisions: %d", len(revisions))
 	}
 
+	// We cannot update the file with this revision ID
+	ce = (*ConflictError)(nil)
+	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test5"), WriteOptions{LatestRevisionID: revisions[0].RevisionID}); err == nil || !errors.As(err, &ce) {
+		t.Errorf("expected error when updating file with zero revision ID: %v", err)
+	}
+
 	// Ensure that we can still create a new revision
-	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test5"), WriteOptions{LatestRevision: revisions[0].RevisionID}); err != nil {
+	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test5"), WriteOptions{LatestRevisionID: latestRevisionID}); err != nil {
 		t.Errorf("error getting file to write: %v", err)
+	}
+
+	// Delete the file
+	if err = s3Prv.DeleteFile(context.Background(), "test.txt"); err != nil {
+		t.Errorf("error removing file: %v", err)
+	}
+}
+
+func TestReadFileWithRevisionS3(t *testing.T) {
+	if skipS3Tests {
+		t.Skip("Skipping S3 tests")
+	}
+
+	// Copy a file into the workspace
+	if err := s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test"), WriteOptions{}); err != nil {
+		t.Fatalf("error getting file to write: %v", err)
+	}
+
+	// Read the file
+	f, err := s3Prv.OpenFile(context.Background(), "test.txt", OpenOptions{WithLatestRevisionID: true})
+	if err != nil {
+		t.Errorf("error reading file: %v", err)
+	}
+
+	// Read the file contents
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Errorf("error reading file contents: %v", err)
+	}
+
+	// Close the file
+	if err := f.Close(); err != nil {
+		t.Errorf("error closing file: %v", err)
+	}
+
+	if string(data) != "test" {
+		t.Errorf("unexpected file contents: %s", string(data))
+	}
+
+	// Ensure that the revision is set and correct.
+	revisionID, err := f.GetRevisionID()
+	if err != nil {
+		t.Errorf("error getting revision: %v", err)
+	}
+	if revisionID != "0" {
+		t.Errorf("unexpected revision ID: %s", revisionID)
+	}
+
+	// Update the file
+	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{LatestRevisionID: "0"}); err != nil {
+		t.Errorf("error getting file to write: %v", err)
+	}
+
+	// Read the file
+	f, err = s3Prv.OpenFile(context.Background(), "test.txt", OpenOptions{WithLatestRevisionID: true})
+	if err != nil {
+		t.Errorf("error reading file: %v", err)
+	}
+
+	// Read the file contents
+	data, err = io.ReadAll(f)
+	if err != nil {
+		t.Errorf("error reading file contents: %v", err)
+	}
+
+	// Close the file
+	if err := f.Close(); err != nil {
+		t.Errorf("error closing file: %v", err)
+	}
+
+	if string(data) != "test2" {
+		t.Errorf("unexpected file contents: %s", string(data))
+	}
+
+	// Get the revision ID
+	revisionID, err = f.GetRevisionID()
+	if err != nil {
+		t.Errorf("error getting revision: %v", err)
+	}
+	if revisionID != "1" {
+		t.Errorf("unexpected revision ID: %s", revisionID)
 	}
 
 	// Delete the file
@@ -629,8 +725,6 @@ func TestDeleteRevisionS3(t *testing.T) {
 	if err = s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test2"), WriteOptions{}); err != nil {
 		t.Errorf("error getting file to write: %v", err)
 	}
-
-	dir, base := filepath.Split(strings.TrimPrefix(directoryTestingID, DirectoryProvider+"://"))
 
 	// Now there should be one revision
 	revisions, err = s3Prv.ListRevisions(context.Background(), "test.txt")
@@ -680,12 +774,12 @@ func TestDeleteRevisionS3(t *testing.T) {
 	}
 
 	// Ensure the file no longer exists
-	if _, err = os.Stat(filepath.Join(dir, base, "test.txt")); !errors.Is(err, os.ErrNotExist) {
+	if _, err := s3Prv.client.GetObject(context.Background(), &s3.GetObjectInput{Bucket: &s3Prv.bucket, Key: aws.String(fmt.Sprintf("%s/%s", s3Prv.dir, "test.txt"))}); err == nil {
 		t.Errorf("file should not exist after deleting: %v", err)
 	}
 
 	// Ensure the revision file no longer exists
-	if _, err = os.Stat(filepath.Join(dir, revisionsDir, base, "test.txt.2")); !errors.Is(err, os.ErrNotExist) {
+	if _, err := s3Prv.client.GetObject(context.Background(), &s3.GetObjectInput{Bucket: &s3Prv.bucket, Key: aws.String(fmt.Sprintf("%s/%s", s3Prv.dir, "test.txt.2"))}); err == nil {
 		t.Errorf("file should not exist after deleting: %v", err)
 	}
 }
@@ -698,5 +792,50 @@ func TestNoCreateRevisionsClientS3(t *testing.T) {
 	_, err := s3Factory.New(fmt.Sprintf("%s://%s/%s", S3Provider, os.Getenv("WORKSPACE_PROVIDER_S3_BUCKET"), revisionsDir))
 	if err == nil {
 		t.Errorf("expected error when creating client for revisions dir")
+	}
+}
+
+func TestStatFileS3(t *testing.T) {
+	if skipS3Tests {
+		t.Skip("Skipping S3 tests")
+	}
+
+	// Copy a file into the workspace
+	if err := s3Prv.WriteFile(context.Background(), "test.txt", strings.NewReader("test"), WriteOptions{}); err != nil {
+		t.Fatalf("error getting file to write: %v", err)
+	}
+
+	// Stat the file
+	providerStat, err := s3Prv.StatFile(context.Background(), "test.txt", StatOptions{})
+	if err != nil {
+		t.Errorf("unexpected error when statting file: %v", err)
+	}
+
+	if providerStat.WorkspaceID != s3TestingID {
+		t.Errorf("unexpected workspace id: %s", providerStat.WorkspaceID)
+	}
+	if providerStat.Size != 4 {
+		t.Errorf("unexpected file size: %d", providerStat.Size)
+	}
+	if providerStat.Name != "test.txt" {
+		t.Errorf("unexpected file name: %s", providerStat.Name)
+	}
+	if providerStat.ModTime.IsZero() {
+		t.Errorf("unexpected file mod time: %s", providerStat.ModTime)
+	}
+	if _, err := providerStat.GetRevisionID(); !errors.Is(err, ErrRevisionNotRequested) {
+		t.Errorf("unexpected error when revision not requested: %v", err)
+	}
+
+	// Stat the file with revision
+	providerStat, err = s3Prv.StatFile(context.Background(), "test.txt", StatOptions{WithLatestRevisionID: true})
+	if err != nil {
+		t.Errorf("unexpected error when statting file: %v", err)
+	}
+
+	if rev, err := providerStat.GetRevisionID(); err != nil {
+		t.Errorf("unexpected error when revision not requested: %v", err)
+	} else if rev != "0" {
+		t.Errorf("unexpected revision id when revision requested: %s", rev)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,6 +24,7 @@ func Run(ctx context.Context, client *client.Client, port int) error {
 	mux.HandleFunc("/rm/{id}", s.rm)
 	mux.HandleFunc("/ls/{id}/{prefix...}", s.ls)
 	mux.HandleFunc("/read-file/{id}/{fileName}", s.readFile)
+	mux.HandleFunc("/read-file-with-revision/{id}/{fileName}", s.readFileWithRevision)
 	mux.HandleFunc("/write-file/{id}/{fileName}", s.writeFile)
 	mux.HandleFunc("/rm-file/{id}/{fileName}", s.deleteFile)
 	mux.HandleFunc("/stat-file/{id}/{fileName}", s.statFile)

--- a/pkg/server/writefile.go
+++ b/pkg/server/writefile.go
@@ -14,8 +14,8 @@ func (s *server) writeFile(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
 	opts := client.WriteOptions{
-		LatestRevision: query.Get("latestRevision"),
-		CreateRevision: toPtr(query.Get("createRevision") != "false"),
+		LatestRevisionID: query.Get("latestRevision"),
+		CreateRevision:   toPtr(query.Get("createRevision") != "false"),
 	}
 
 	if err := s.client.WriteFile(r.Context(), id, fileName, base64.NewDecoder(base64.StdEncoding, r.Body), opts); err != nil {

--- a/tool.gpt
+++ b/tool.gpt
@@ -50,9 +50,17 @@ Tools: Server
 Description: Read a file in a workspace, returned the base64 encoded content
 Parameter: workspace_id: The ID of the workspaces to read the file from
 Parameter: file_path: The name of the file to read
-Parameter: with_latest_revision_id: Whether to return the latest revision ID (optional)
 
-#!http://Server.daemon.gptscript.local/read-file/${WORKSPACE_ID}/${FILE_PATH}?withLatestRevision=${WITH_LATEST_REVISION_ID}
+#!http://Server.daemon.gptscript.local/read-file/${WORKSPACE_ID}/${FILE_PATH}
+
+---
+Name: Read File With Revision in Workspace
+Tools: Server
+Description: Read a file in a workspace, returned the base64 encoded content
+Parameter: workspace_id: The ID of the workspaces to read the file from
+Parameter: file_path: The name of the file to read
+
+#!http://Server.daemon.gptscript.local/read-file-with-revision/${WORKSPACE_ID}/${FILE_PATH}
 
 ---
 Name: Remove File in Workspace

--- a/tool.gpt
+++ b/tool.gpt
@@ -40,9 +40,9 @@ Parameter: workspace_id: The ID of the workspaces to write the file in
 Parameter: file_path: The name of the file to write
 Parameter: body: The base64 encoded contents of the file to write
 Parameter: create_revision: Whether to create a revision of the change to the file
-Parameter: latest_revision: Only write the file if the given revision is the latest (optional)
+Parameter: latest_revision_id: Only write the file if the given revision is the latest (optional)
 
-#!http://Server.daemon.gptscript.local/write-file/${WORKSPACE_ID}/${FILE_PATH}?createRevision=${CREATE_REVISION}&latestRevision=${LATEST_REVISION}
+#!http://Server.daemon.gptscript.local/write-file/${WORKSPACE_ID}/${FILE_PATH}?createRevision=${CREATE_REVISION}&latestRevision=${LATEST_REVISION_ID}
 
 ---
 Name: Read File in Workspace
@@ -50,8 +50,9 @@ Tools: Server
 Description: Read a file in a workspace, returned the base64 encoded content
 Parameter: workspace_id: The ID of the workspaces to read the file from
 Parameter: file_path: The name of the file to read
+Parameter: with_latest_revision_id: Whether to return the latest revision ID (optional)
 
-#!http://Server.daemon.gptscript.local/read-file/${WORKSPACE_ID}/${FILE_PATH}
+#!http://Server.daemon.gptscript.local/read-file/${WORKSPACE_ID}/${FILE_PATH}?withLatestRevision=${WITH_LATEST_REVISION_ID}
 
 ---
 Name: Remove File in Workspace
@@ -68,8 +69,9 @@ Tools: Server
 Description: Get information about a file in a workspace
 Parameter: workspace_id: The ID of the workspaces to stat the file from
 Parameter: file_path: The name of the file to stat
+Parameter: with_latest_revision_id: Whether to return the latest revision ID (optional)
 
-#!http://Server.daemon.gptscript.local/stat-file/${WORKSPACE_ID}/${FILE_PATH}
+#!http://Server.daemon.gptscript.local/stat-file/${WORKSPACE_ID}/${FILE_PATH}?withLatestRevision=${WITH_LATEST_REVISION_ID}
 
 ---
 Name: List Revisions for File in Workspace


### PR DESCRIPTION
This change also has some changes to make the revision ID names and field
consistent.

Issue: https://github.com/obot-platform/obot/issues/1711